### PR TITLE
Fix PlainTextLength issue #10

### DIFF
--- a/pkg/v1/bunt/bunt.go
+++ b/pkg/v1/bunt/bunt.go
@@ -148,7 +148,7 @@ func BoldText(text string) string {
 
 // RemoveAllEscapeSequences return the input string with all escape sequences removed
 func RemoveAllEscapeSequences(input string) string {
-	escapeSeqFinderRegExp := regexp.MustCompile(seq + `\[\d+(;\d+)*m`)
+	escapeSeqFinderRegExp := regexp.MustCompile(seq + `\[([\d;]*)m`)
 
 	for loc := escapeSeqFinderRegExp.FindStringIndex(input); loc != nil; loc = escapeSeqFinderRegExp.FindStringIndex(input) {
 		start := loc[0]

--- a/pkg/v1/bunt/bunt_test.go
+++ b/pkg/v1/bunt/bunt_test.go
@@ -210,4 +210,10 @@ var _ = Describe("Bunt tests", func() {
 			Expect(Get4bitEquivalentColorAttribute(WhiteSmoke)).To(BeEquivalentTo(Attribute(97)))           // WhiteSmoke matches BrightWhite (#97)
 		})
 	})
+
+	Context("Reported Issues", func() {
+		It("should return the correct text length of a string with ANSI sequences (https://github.com/homeport/gonvenience/issues/10)", func() {
+			Expect(PlainTextLength("\x1b[0;32mINFO \x1b[mNo dependencies found")).To(BeEquivalentTo(len("INFO No dependencies found")))
+		})
+	})
 })


### PR DESCRIPTION
Fix issue #10 in function PlainTextLength by searching improving the
regular expression for the ANSI sequence. The updated expression matches
empty ANSI sequences, too. By definition, a SGI ANSI sequence (coloring),
which does not have any number specified has to be treated as code 0.

https://en.wikipedia.org/wiki/ANSI_escape_code#SGR