### PR TITLE
Fix issue indicator text exceeds terminal width

### DIFF
--- a/pkg/v1/text/text.go
+++ b/pkg/v1/text/text.go
@@ -23,7 +23,10 @@ package text
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
+
+	"github.com/homeport/gonvenience/pkg/v1/bunt"
 )
 
 const chars = "abcdefghijklmnopqrstuvwxyz"
@@ -58,4 +61,21 @@ func RandomStringWithPrefix(prefix string, length int) string {
 	}
 
 	return prefix + RandomString(length-len(prefix))
+}
+
+// FixedLength expands or trims the given text to the provided length
+func FixedLength(text string, length int) string {
+	textLength := bunt.PlainTextLength(text)
+
+	switch {
+	case textLength < length: // padding required
+		return text + strings.Repeat(" ", length-textLength)
+
+	case textLength > length:
+		const ellipsis = " [...]"
+		return text[:length-len(ellipsis)] + ellipsis
+
+	default:
+		return text
+	}
 }

--- a/pkg/v1/text/text_test.go
+++ b/pkg/v1/text/text_test.go
@@ -63,4 +63,18 @@ var _ = Describe("Generate random strings with fixed length", func() {
 			RandomStringWithPrefix("foobar", -1)
 		})
 	})
+
+	Context("Text with given fixed length", func() {
+		It("should create a string with the text and enough padding to fill it up to the required length", func() {
+			Expect(FixedLength("Foobar", 10)).To(BeEquivalentTo("Foobar    "))
+		})
+
+		It("should trim the text if the text alone exceeds the provided desired length", func() {
+			Expect(FixedLength("This text is too long", 10)).To(BeEquivalentTo("This [...]"))
+		})
+
+		It("should return the text as-is if it already has the perfect length", func() {
+			Expect(FixedLength("Foobar", 6)).To(BeEquivalentTo("Foobar"))
+		})
+	})
 })

--- a/pkg/v1/wait/wait.go
+++ b/pkg/v1/wait/wait.go
@@ -63,6 +63,7 @@ import (
 
 	"github.com/homeport/gonvenience/pkg/v1/bunt"
 	"github.com/homeport/gonvenience/pkg/v1/term"
+	"github.com/homeport/gonvenience/pkg/v1/text"
 )
 
 const resetLine = "\r\x1b[K"
@@ -130,9 +131,7 @@ func (pi *ProgressIndicator) Start() *ProgressIndicator {
 				mainContentText := removeLineFeeds(bunt.Sprintf(pi.format, pi.args...))
 				elapsedTimeText, elapsedTimeColor := pi.timeInfoText(elapsedTime)
 
-				padding := term.GetTerminalWidth() - 3 -
-					bunt.PlainTextLength(mainContentText) -
-					bunt.PlainTextLength(elapsedTimeText)
+				availableSpace := term.GetTerminalWidth() - 3 - bunt.PlainTextLength(elapsedTimeText)
 
 				// In case a timeout is set, smoothly blend the time info text color from
 				// the provided color into red depending on how much time is left
@@ -144,8 +143,7 @@ func (pi *ProgressIndicator) Start() *ProgressIndicator {
 
 				bunt.Fprint(pi.out,
 					resetLine, " ", pi.nextSymbol(), " ",
-					mainContentText,
-					strings.Repeat(" ", padding),
+					text.FixedLength(mainContentText, availableSpace),
 					bunt.Colorize(elapsedTimeText, elapsedTimeColor),
 				)
 


### PR DESCRIPTION
Introduce text function to enforce a given length to a text.

Use new text function to make sure the text length does not exceeds the terminal width.

Should fix #13 