### PR TITLE
Fix Concourse coloring issues

### DIFF
--- a/pkg/v1/bunt/ansistring.go
+++ b/pkg/v1/bunt/ansistring.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/homeport/gonvenience/pkg/v1/term"
 	"github.com/lucasb-eyer/go-colorful"
 )
 
@@ -71,8 +72,14 @@ func markerToSeq(m marker) string {
 	values = append(values, m.codes...)
 
 	if m.fgColor != nil {
-		r, g, b := (*m.fgColor).RGB255()
-		values = append(values, 38, 2, r, g, b)
+		if term.IsTrueColor() {
+			r, g, b := (*m.fgColor).RGB255()
+			values = append(values, 38, 2, r, g, b)
+
+		} else {
+			attr := Get4bitEquivalentColorAttribute(*m.fgColor)
+			values = append(values, uint8(attr))
+		}
 	}
 
 	return ansiSeq(values...)

--- a/pkg/v1/bunt/ansistring_test.go
+++ b/pkg/v1/bunt/ansistring_test.go
@@ -22,6 +22,7 @@ package bunt_test
 
 import (
 	"fmt"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,6 +34,7 @@ var _ = Describe("ANSI string tests", func() {
 	BeforeEach(func() {
 		ColorSetting = ON
 		TrueColorSetting = ON
+		os.Setenv("COLORTERM", "truecolor")
 	})
 
 	Context("Testing Sprint wrapper function", func() {

--- a/pkg/v1/term/term.go
+++ b/pkg/v1/term/term.go
@@ -67,6 +67,14 @@ func GetTerminalHeight() int {
 // used: 80x25. A manual override is possible using FixedTerminalWidth
 // and FixedTerminalHeight.
 func GetTerminalSize() (int, int) {
+	// In case this is a garden container, disable the terminal size detection
+	// and fall back to a reasonable assumption that is a bit bigger in size
+	// than the default terminal fallback dimensions.
+	if FixedTerminalWidth < 0 && FixedTerminalHeight < 0 && IsGardenContainer() {
+		FixedTerminalWidth = 120
+		FixedTerminalHeight = 25
+	}
+
 	// Return user preference (explicit overwrite) of both width and height
 	if FixedTerminalWidth > 0 && FixedTerminalHeight > 0 {
 		return FixedTerminalWidth, FixedTerminalHeight


### PR DESCRIPTION
Fix terminal length issue in Concourse tasks where the autodection uses the
provided termainal size by Garden of around 500 characters. Force a reasonable
terminal width of 120 characters instead.

Fix true color issue in Concourse, where the Ansistring print functions did
not check for the true color settings of the shell and always assumed 24 bit
color support.