### PR TITLE
Add plural function to text package

### DIFF
--- a/pkg/v1/text/text.go
+++ b/pkg/v1/text/text.go
@@ -23,6 +23,7 @@ package text
 import (
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 
@@ -41,7 +42,7 @@ func RandomString(length int) string {
 		panic(fmt.Errorf("negative length value"))
 	}
 
-	tmp := make([]byte, length, length)
+	tmp := make([]byte, length)
 	for i := range tmp {
 		tmp[i] = chars[rand.Intn(len(chars))]
 	}
@@ -77,5 +78,36 @@ func FixedLength(text string, length int) string {
 
 	default:
 		return text
+	}
+}
+
+// Plural returns a string with the number and noun in either singular or plural form.
+// If one text argument is given, the plural will be done with the plural s. If two
+// arguments are provided, the second text is the irregular plural. If more than two
+// are provided, then the additional ones are simply ignored.
+func Plural(amount int, text ...string) string {
+	words := [...]string{"no", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "eleven", "twelve"}
+
+	var number string
+	if amount < len(words) {
+		number = words[amount]
+	} else {
+		number = strconv.Itoa(amount)
+	}
+
+	switch len(text) {
+	case 1:
+		if amount == 1 {
+			return fmt.Sprintf("%s %s", number, text[0])
+		}
+
+		return fmt.Sprintf("%s %ss", number, text[0])
+
+	default:
+		if amount == 1 {
+			return fmt.Sprintf("%s %s", number, text[0])
+		}
+
+		return fmt.Sprintf("%s %s", number, text[1])
 	}
 }

--- a/pkg/v1/text/text_test.go
+++ b/pkg/v1/text/text_test.go
@@ -90,4 +90,27 @@ var _ = Describe("Generate random strings with fixed length", func() {
 			Expect(fmt.Sprintf("%#v", actual)).To(BeEquivalentTo(fmt.Sprintf("%#v", expected)))
 		})
 	})
+
+	Context("creating proper texts", func() {
+		It("should return human readable plurals", func() {
+			Expect(Plural(0, "foobar")).To(BeEquivalentTo("no foobars"))
+			Expect(Plural(1, "foobar")).To(BeEquivalentTo("one foobar"))
+			Expect(Plural(2, "foobar")).To(BeEquivalentTo("two foobars"))
+			Expect(Plural(3, "foobar")).To(BeEquivalentTo("three foobars"))
+			Expect(Plural(4, "foobar")).To(BeEquivalentTo("four foobars"))
+			Expect(Plural(5, "foobar")).To(BeEquivalentTo("five foobars"))
+			Expect(Plural(6, "foobar")).To(BeEquivalentTo("six foobars"))
+			Expect(Plural(7, "foobar")).To(BeEquivalentTo("seven foobars"))
+			Expect(Plural(8, "foobar")).To(BeEquivalentTo("eight foobars"))
+			Expect(Plural(9, "foobar")).To(BeEquivalentTo("nine foobars"))
+			Expect(Plural(10, "foobar")).To(BeEquivalentTo("ten foobars"))
+			Expect(Plural(11, "foobar")).To(BeEquivalentTo("eleven foobars"))
+			Expect(Plural(12, "foobar")).To(BeEquivalentTo("twelve foobars"))
+			Expect(Plural(13, "foobar")).To(BeEquivalentTo("13 foobars"))
+			Expect(Plural(147, "foobar")).To(BeEquivalentTo("147 foobars"))
+
+			Expect(Plural(1, "basis", "bases")).To(BeEquivalentTo("one basis"))
+			Expect(Plural(2, "basis", "bases")).To(BeEquivalentTo("two bases"))
+		})
+	})
 })


### PR DESCRIPTION
Add plural function to text package to create correct plural forms.

Fix `staticcheck` finding regarding make call.

Should fix #17.