### PR TITLE
Use stderr for progress indicator

### DIFF
--- a/pkg/v1/wait/wait.go
+++ b/pkg/v1/wait/wait.go
@@ -95,10 +95,10 @@ type ProgressIndicator struct {
 // supplied during runtime.
 func NewProgressIndicator(format string, args ...interface{}) *ProgressIndicator {
 	return &ProgressIndicator{
-		out:          os.Stdout,
+		out:          os.Stderr,
 		format:       format,
 		args:         args,
-		spin:         term.IsTerminal() && !term.IsDumbTerminal(),
+		spin:         !term.IsDumbTerminal(),
 		timeout:      0 * time.Second,
 		timeInfoText: TimeInfoText,
 	}


### PR DESCRIPTION
Based on https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html,
use `stderr` as the default output for the progress indicator. Also show the progress
indicator if the program is used in a pipe as it should not spoil the output anymore.

Should fix #22.