### PR TITLE
Introduce wrap package

### DIFF
--- a/pkg/v1/wrap/error.go
+++ b/pkg/v1/wrap/error.go
@@ -1,0 +1,56 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/*
+Package wrap contains code to simply wrap an error into a bit of context.
+*/
+package wrap
+
+import "fmt"
+
+// ContextError interface describes the simple type that is able to provide a
+// textual context as well as the cause explaining the underlying error.
+type ContextError interface {
+	Context() string
+	Cause() error
+}
+
+// wrappedError describes an error with added context information
+type wrappedError struct {
+	context string
+	cause   error
+}
+
+func (e *wrappedError) Error() string {
+	return fmt.Sprintf("%s: %v", e.context, e.cause)
+}
+
+func (e *wrappedError) Context() string {
+	return e.context
+}
+
+func (e *wrappedError) Cause() error {
+	return e.cause
+}
+
+// Error creates an error with additional context
+func Error(err error, context string) error {
+	return &wrappedError{context, err}
+}

--- a/pkg/v1/wrap/error_test.go
+++ b/pkg/v1/wrap/error_test.go
@@ -1,0 +1,64 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package wrap_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/homeport/gonvenience/pkg/v1/wrap"
+)
+
+var _ = Describe("wrap package tests", func() {
+	Context("wrapping errors in context", func() {
+		var err = Error(
+			fmt.Errorf("failed to do x, because of y"),
+			"issue setting up z",
+		)
+
+		It("should behave and render like a standard error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(BeEquivalentTo("issue setting up z: failed to do x, because of y"))
+		})
+
+		It("should be able to just extract the context string", func() {
+			switch contextError := err.(type) {
+			case ContextError:
+				Expect(contextError.Context()).To(BeEquivalentTo("issue setting up z"))
+
+			default:
+				Fail("failed to type cast to ContextError")
+			}
+		})
+
+		It("should be able to just extract the error cause", func() {
+			switch contextError := err.(type) {
+			case ContextError:
+				Expect(contextError.Cause().Error()).To(BeEquivalentTo("failed to do x, because of y"))
+
+			default:
+				Fail("failed to type cast to ContextError")
+			}
+		})
+	})
+})

--- a/pkg/v1/wrap/wrap_suite_test.go
+++ b/pkg/v1/wrap/wrap_suite_test.go
@@ -1,0 +1,33 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package wrap_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestWrap(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "wrap suite")
+}


### PR DESCRIPTION
Add wrap package to gonvenience.

Add simple interface for a context error, where an error can be wrapped
with additional textual context information.